### PR TITLE
Add laws tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Extended relations are the ones that compose of several basic relations.
 Determines whether `a` is a subset of `b`.
 
 ```text
-  isSubset                         AAAAA            | a- >= b- AND a+ <= b+
+  a.isSubset(b)                    AAAAA            | a- >= b- AND a+ <= b+
                                    :   :
   a.starts(b)         s            BBBBBBBBB        | a- = b- ; a+ < b+
   a.during(b)         d          BBBBBBBBB          | a- > b- ; a+ < b+
@@ -175,7 +175,7 @@ Interval.open(4, 7).isSubset(Interval.open(4, 7))  // true
 Determines whether `a` is a superset of `b`.
 
 ```text
-  isSuperset                       AAAAA            | b- >= a- AND b+ <= a+
+  a.isSuperset(b)                  AAAAA            | b- >= a- AND b+ <= a+
                                    :   :
   a.isStartedBy(b)    S            BBB :            | a- = b- ; b+ < a+
   a.contains(b)       D            : B :            | a- < b- ; b+ < a+
@@ -195,7 +195,7 @@ Interval.open(4, 7).isSuperset(Interval.open(4, 7))  // true
 Determines if there `a` and `b` are disjoint. `a` and `b` are disjoint if `a` does not intersect `b`.
 
 ```text
-  isDisjoint                       AAAAA            | a+ < b- OR a- > b+
+  a.isDisjoint(b)                  AAAAA            | a+ < b- OR a- > b+
                                    :   :
   a.before(b)         b            :   : BBBBBBBBB  | a+ < b-
   a.after(b)          B  BBBBBBBBB :   :            | a- > b+
@@ -211,7 +211,7 @@ Interval.open(3, 6).isDisjoint(Interval.open(1, 4)) // true
 Two intervals `a` and `b` are adjacent if they are disjoint and `succ(a+) = b- OR succ(b+) = a-`
 
 ```text
-  isAdjacent                       AAAAA            |  succ(a+) = b- OR succ(b+) = a-
+  a.isAdjacent(b)                  AAAAA            |  succ(a+) = b- OR succ(b+) = a-
                                    :   :
   a.before(b)         b            :   : BBBBBBBBB  | a+ < b- ; succ(a+) = b-
   a.after(b)          B  BBBBBBBBB :   :            | a- > b+ ; succ(b+) = a-
@@ -229,7 +229,7 @@ Interval.closed(5, 6).isAdjacent(Interval.closed(1, 4)) // true
 Two intervals `a` and `b` are intersecting if: `a- <= b+ AND b- <= a+`
 
 ```text
-  intersects                       AAAAA            | a- <= b+ AND b- <= a+
+  a.intersects(b)                  AAAAA            | a- <= b+ AND b- <= a+
                                    :   :
   a.meets(b)          m            :   BBBBBBBBB    | a+ = b-
   a.overlaps(b)       o            : BBBBBBBBB      | a- < b- < a+ < b+
@@ -255,7 +255,7 @@ Interval.closed(0, 5).intersects(Interval.closed(1, 6)) // true
 Two intervals `a` and `b` can be merged, if they are adjacent or intersect.
 
 ```text
-  merges                           AAAAA            | intersects(a,b) OR isAdjacent(a,b)
+  a.merges(b)                      AAAAA            | intersects(a,b) OR isAdjacent(a,b)
                                    :   :
   a.before(b)         b            :   : BBBBBBBBB  | a+ < b- ; succ(a+) = b-
   a.meets(b)          m            :   BBBBBBBBB    | a+ = b-
@@ -279,10 +279,10 @@ Interval.open(4, 10).merges(Interval.open(5, 12)) // true
 
 ### IsLess
 
-Determines whether `a` less-than `b`.
+Determines whether `a` is less-than `b`.
 
 ```text
-  isLess                           AAAAA            | a- < b- AND a+ < b+
+  a.isLess(b)                      AAAAA            | a- < b- AND a+ < b+
                                    :   :
   a.before(b)         b            :   : BBBBBBBBB  | a+ < b-
   a.meets(b)          m            :   BBBBBBBBB    | a+ = b-
@@ -294,6 +294,26 @@ Interval.open(4, 7).isLess(Interval.open(10, 15)) // true
 Interval.open(4, 7).isLess(Interval.open(6, 15))  // true
 Interval.open(4, 7).isLess(Interval.open(5, 15))  // true
 ```
+
+### IsGreater
+
+Determines whether `a` is greater-than `b`.
+
+```text
+  a.isGreater                      AAAAA            | a- < b- AND a+ < b+
+                                   :   :
+  a.after(b)          B  BBBBBBBBB :   :            | a- > b+
+  a.isMetBy(b)        M    BBBBBBBBB   :            | a- = b+
+  a.isOverlappedBy(b) O      BBBBBBBBB :            | b- < a- < b+ < a+
+```
+
+```scala
+Interval.open(10, 15).isGreater(Interval.open(4, 7)) // true
+Interval.open(6, 15).isGreater(Interval.open(4, 7))  // true
+Interval.open(5, 15).isGreater(Interval.open(4, 7))  // true
+```
+
+NOTE: empty intervals cannot be compared -- operations `isLess`, `isGreater`, `equalsTo` return `false`.
 
 ## Operations
 
@@ -390,7 +410,7 @@ val c = a.union(b)             // ∅
 
 ### Gap
 
-A gap between two intervals `a` and `b`: `a || b := [min(a-, b-), max(a+, b+)]`.
+A gap between two intervals `a` and `b`: `a ∥ b := [min(a-, b-), max(a+, b+)]`.
 
 ```scala
 val a = Interval.closed(5, 10)   // [5, 10]

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # TODO
 
+- add laws tests
 - add COUNT -- or size to get the cardinality, add it to Domain (Ordinal)
-- - canonical - add a method to convert to [) interval
+- canonical - add a method to convert to [) interval
 - add more operators and law tests

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 # TODO
 
 - add laws tests
+- add laws to the documentation??
 - add COUNT -- or size to get the cardinality, add it to Domain (Ordinal)
 - canonical - add a method to convert to [) interval
 - add more operators and law tests

--- a/src/main/scala/com/github/gchudnov/mtg/Boundary.scala
+++ b/src/main/scala/com/github/gchudnov/mtg/Boundary.scala
@@ -81,3 +81,9 @@ object Boundary:
 
   given boundaryOrdering[T: Ordering: Domain]: Ordering[Boundary[T]] =
     new BoundaryOrdering
+
+  def left[T](value: Option[T], isInclude: Boolean): Boundary.Left[T] =
+    Boundary.Left(value, isInclude)
+
+  def right[T](value: Option[T], isInclude: Boolean): Boundary.Right[T] =
+    Boundary.Right(value, isInclude)

--- a/src/main/scala/com/github/gchudnov/mtg/internal/OpsBasic.scala
+++ b/src/main/scala/com/github/gchudnov/mtg/internal/OpsBasic.scala
@@ -32,6 +32,11 @@ private[mtg] transparent trait BasicOps[+T]:
     if a.isEmpty || b.isEmpty then Interval.empty[T]
     else Interval.make(ordT.max(a.left, b.left), ordT.min(a.right, b.right))
 
+  /*
+    if (a.nonEmpty && b.nonEmpty) && (ordT.lteq(a.left, b.right) && ordT.lteq(b.left, a.right)) then Interval.make(ordT.max(a.left, b.left), ordT.min(a.right, b.right))
+    else Interval.empty[T]
+   */
+
   /**
    * Span
    *
@@ -100,12 +105,12 @@ private[mtg] transparent trait BasicOps[+T]:
   /**
    * Gap (Complement)
    *
-   *   - A || B
+   *   - A ∥ B
    *
-   * A gap between two intervals `a` and `b`: `a || b := [min(a-, b-), max(a+, b+)]`.
+   * A gap between two intervals `a` and `b`: `a ∥ b := [min(a-, b-), max(a+, b+)]`.
    *
    * {{{
-   *   A || B := [min(a+, b+), max(a-, b-)]
+   *   A ∥ B := [min(a+, b+), max(a-, b-)]
    *
    *   [***********]                          | [5,10]
    *                          [***********]   | [15,20]
@@ -115,8 +120,9 @@ private[mtg] transparent trait BasicOps[+T]:
    * }}}
    */
   final def gap[T1 >: T: Domain](b: Interval[T1])(using ordT: Ordering[Boundary[T1]]): Interval[T1] =
-    if a.isEmpty || b.isEmpty then Interval.empty[T]
-    else Interval.make(ordT.min(a.right, b.right).succ.asLeft, ordT.max(a.left, b.left).pred.asRight)
+    if (a.nonEmpty && b.nonEmpty) && (ordT.lt(b.right, a.left) || ordT.lt(a.right, b.left)) then
+      Interval.make(ordT.min(a.right, b.right).succ.asLeft, ordT.max(a.left, b.left).pred.asRight)
+    else Interval.empty[T]
 
   /**
    * Minus
@@ -129,7 +135,7 @@ private[mtg] transparent trait BasicOps[+T]:
    * NOTE: a.minus(b) is defined only if and only if:
    *   - (a) `a` and `b` are disjoint;
    *   - (b) `a` contains either `b-` or `b+` but not both;
-   *   - (c) either b.starts(a) or b.finishes(a) is trye;
+   *   - (c) either b.starts(a) or b.finishes(a) is true;
    *
    * NOTE: a.minus(b) is undefined if:
    *   - either a.starts(b) or a.finishes(b);

--- a/src/main/scala/com/github/gchudnov/mtg/internal/RelBasic.scala
+++ b/src/main/scala/com/github/gchudnov/mtg/internal/RelBasic.scala
@@ -96,7 +96,7 @@ private[mtg] transparent trait BasicRel[+T]:
     b.overlaps(a)
 
   /**
-   * During, IncludedIn (d)
+   * During, ProperlyIncludedIn (d)
    *
    * {{{
    *   PI (Point-Interval):
@@ -120,7 +120,7 @@ private[mtg] transparent trait BasicRel[+T]:
     a.nonEmpty && b.isProper && bOrd.lt(b.left, a.left) && bOrd.lt(a.right, b.right)
 
   /**
-   * Contains, Includes (D)
+   * Contains, ProperlyIncludes (D)
    */
   final def contains[T1 >: T](b: Interval[T1])(using bOrd: Ordering[Boundary[T1]]): Boolean =
     b.during(a)

--- a/src/main/scala/com/github/gchudnov/mtg/internal/RelExtended.scala
+++ b/src/main/scala/com/github/gchudnov/mtg/internal/RelExtended.scala
@@ -11,8 +11,9 @@ import com.github.gchudnov.mtg.Domain
  *   - IsSuperset
  *   - IsDisjoint
  *   - IsAdjacent
- *   - Merges, IsMergedBy
+ *   - Merges
  *   - IsLess
+ *   - IsGreater
  */
 private[mtg] transparent trait ExtendedRel[+T]:
   a: Interval[T] =>
@@ -132,7 +133,7 @@ private[mtg] transparent trait ExtendedRel[+T]:
    * }}}
    */
   final def merges[T1 >: T: Domain](b: Interval[T1])(using bOrd: Ordering[Boundary[T1]]): Boolean =
-    a.nonEmpty && b.nonEmpty && ((bOrd.lteq(a.left, b.right) && bOrd.lteq(b.left, a.right)) || (bOrd.equiv(a.right.succ, b.left) || bOrd.equiv(b.right.succ, a.left)))
+    (a.isEmpty || b.isEmpty) || ((bOrd.lteq(a.left, b.right) && bOrd.lteq(b.left, a.right)) || (bOrd.equiv(a.right.succ, b.left) || bOrd.equiv(b.right.succ, a.left)))
 
   /**
    * IsMergedBy

--- a/src/main/scala/com/github/gchudnov/mtg/internal/RelExtended.scala
+++ b/src/main/scala/com/github/gchudnov/mtg/internal/RelExtended.scala
@@ -42,6 +42,8 @@ private[mtg] transparent trait ExtendedRel[+T]:
    *
    * Checks whether A is a superset of B
    *
+   * A ⊇ B
+   *
    * {{{
    *   b- >= a-
    *   b+ <= a+
@@ -141,7 +143,7 @@ private[mtg] transparent trait ExtendedRel[+T]:
   /**
    * IsLess
    *
-   * Checks whether A less-than B (Order Relation)
+   * Checks whether A is less-than B (Order Relation)
    *
    * A < B
    *
@@ -156,3 +158,22 @@ private[mtg] transparent trait ExtendedRel[+T]:
    */
   final def isLess[T1 >: T](b: Interval[T1])(using bOrd: Ordering[Boundary[T1]]): Boolean =
     a.nonEmpty && b.nonEmpty && bOrd.lt(a.left, b.left) && bOrd.lt(a.right, b.right)
+
+  /**
+   * IsGreater
+   *
+   * Checks whether A is greater-than B (Order Relation)
+   *
+   * A > B
+   *
+   * {{{
+   *   a- > b-
+   *   a+ > b+
+   *
+   *   after          | B
+   *   isMetBy        | M
+   *   isOverlappedBy | O
+   * }}}
+   */
+  final def isGreater[T1 >: T](b: Interval[T1])(using bOrd: Ordering[Boundary[T1]]): Boolean =
+    a.nonEmpty && b.nonEmpty && bOrd.gt(a.left, b.left) && bOrd.gt(a.right, b.right)

--- a/src/test/scala/com/github/gchudnov/mtg/IntervalSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/IntervalSpec.scala
@@ -65,10 +65,13 @@ final class IntervalSpec extends TestSpec:
 
       "handle edge cases" in {
         // [0, 0)
-        Interval.make(Some(0), true, Some(0), false).isEmpty mustBe (true)
+        Interval.make(Some(0), true, Some(0), false) mustBe Interval.empty[Int]
 
         // [-inf, +inf]
-        Interval.make[Int](None, true, None, true).isEmpty mustBe (false)
+        Interval.make[Int](None, true, None, true).isUnbounded mustBe true
+
+        // (-inf, +inf)
+        Interval.make[Int](None, false, None, false) mustBe Interval.unbounded[Int]
 
         // (3, 5)
         Interval.make(Some(3), false, Some(5), false) mustBe Interval.point(4)
@@ -81,12 +84,15 @@ final class IntervalSpec extends TestSpec:
 
         // [4, 5)
         Interval.make(Some(4), true, Some(5), false) mustBe Interval.point(4)
+
+        // [-inf, inf]
+
       }
     }
 
     "factory methods" should {
 
-      "construct an empty interval with type parameter" in {
+      "Interval.empty[Int]" in {
         val a = Interval.empty[Int]
 
         a.isEmpty mustBe (true)
@@ -109,7 +115,7 @@ final class IntervalSpec extends TestSpec:
         }
       }
 
-      "construct an empty interval without type parameter" in {
+      "Interval.empty" in {
         val a = Interval.empty
 
         a.isEmpty mustBe (true)
@@ -132,7 +138,7 @@ final class IntervalSpec extends TestSpec:
         }
       }
 
-      "construct a point interval" in {
+      "Interval.point(x)" in {
         val a = Interval.point(5)
 
         a.isEmpty mustBe (false)
@@ -153,7 +159,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (false)
       }
 
-      "construct a proper interval" in {
+      "Interval.proper(x, y, w, z)" in {
         val a = Interval.proper(Some(1), false, Some(5), false)
 
         a.isEmpty mustBe (false)
@@ -174,7 +180,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (false)
       }
 
-      "construct a proper interval with left and right boundaries" in {
+      "Interval.proper(a, b)" in {
         val a = Interval.proper(Boundary.Left(Some(1), true), Boundary.Right(Some(5), true))
 
         a.isEmpty mustBe (false)
@@ -195,7 +201,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (false)
       }
 
-      "construct an unbounded interval" in {
+      "Interval.unbounded[Int]" in {
         val a = Interval.unbounded[Int]
 
         a.isEmpty mustBe (false)
@@ -216,7 +222,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (true)
       }
 
-      "construct an open interval" in {
+      "Interval.open(x, y)" in {
         val a = Interval.open(1, 5)
 
         a.isEmpty mustBe (false)
@@ -237,7 +243,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (false)
       }
 
-      "construct a closed interval" in {
+      "Interval.closed(x, y)" in {
         val a = Interval.closed(1, 5)
 
         a.isEmpty mustBe (false)
@@ -258,7 +264,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (false)
       }
 
-      "construct a leftOpen interval" in {
+      "Interval.leftOpen(x)" in {
         val a = Interval.leftOpen(1)
 
         a.isEmpty mustBe (false)
@@ -279,7 +285,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (true)
       }
 
-      "construct a leftClosed interval" in {
+      "Interval.leftClosed(x)" in {
         val a = Interval.leftClosed(5)
 
         a.isEmpty mustBe (false)
@@ -300,7 +306,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (true)
       }
 
-      "construct a rightOpen interval" in {
+      "Interval.rightOpen(x)" in {
         val a = Interval.rightOpen(1)
 
         a.isEmpty mustBe (false)
@@ -321,7 +327,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (false)
       }
 
-      "construct a rightClosed interval" in {
+      "Interval.rightClosed(x)" in {
         val a = Interval.rightClosed(5)
 
         a.isEmpty mustBe (false)
@@ -342,7 +348,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (false)
       }
 
-      "construct a leftClosedRightOpen interval" in {
+      "Interval.leftClosedRightOpen(x, y)" in {
         val a = Interval.leftClosedRightOpen(1, 10)
 
         a.isEmpty mustBe (false)
@@ -363,7 +369,7 @@ final class IntervalSpec extends TestSpec:
         a.right.isUnbounded mustBe (false)
       }
 
-      "construct a leftOpenRightClosed interval" in {
+      "Interval.leftOpenRightClosed(x, y)" in {
         val a = Interval.leftOpenRightClosed(1, 10)
 
         a.isEmpty mustBe (false)
@@ -387,7 +393,7 @@ final class IntervalSpec extends TestSpec:
     }
 
     "canonical" should {
-      "include all boundaries" in {
+      "represent" in {
         // (1, 5) = [2, 4]
         Interval.open(1, 5).canonical mustBe Interval.closed(2, 4)
 

--- a/src/test/scala/com/github/gchudnov/mtg/LawsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/LawsSpec.scala
@@ -13,6 +13,7 @@ final class LawsSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Laws" when {
+
     "a.intersection(b) is defined" should {
       "a.UNION(b) is certainly defined as well" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
@@ -25,4 +26,5 @@ final class LawsSpec extends TestSpec:
         }
       }
     }
+
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/BeforeSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/BeforeSpec.scala
@@ -1,6 +1,7 @@
 package com.github.gchudnov.mtg.internal
 
 import com.github.gchudnov.mtg.Arbitraries.*
+import com.github.gchudnov.mtg.Boundary
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
@@ -20,6 +21,8 @@ final class BeforeSpec extends TestSpec:
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
+
   "Before" when {
     import IntervalRelAssert.*
 
@@ -33,6 +36,12 @@ final class BeforeSpec extends TestSpec:
             yy.after(xx) mustBe true
 
             assertOne(Rel.Before)(xx, yy)
+
+            // a+ < b-
+            val a2 = Boundary.Right(ox2, ix2)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            ordB.lt(a2, b1) mustBe true
           }
         }
       }
@@ -48,6 +57,12 @@ final class BeforeSpec extends TestSpec:
             yy.before(xx) mustBe true
 
             assertOne(Rel.After)(xx, yy)
+
+            // a- > b+
+            val a1 = Boundary.Left(ox1, ix1)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            ordB.gt(a1, b2) mustBe true
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/BeforeSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/BeforeSpec.scala
@@ -21,21 +21,53 @@ final class BeforeSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Before" when {
-    "before (preceeds) & after (isPreceededBy)" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.before(b)" should {
+      "b.after(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.before(yy)) {
+            yy.after(xx) mustBe true
+
             assertOne(Rel.Before)(xx, yy)
           }
         }
       }
+    }
 
-      "manual check" in {
+    "a.after(b)" should {
+      "b.before(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(xx.after(yy)) {
+            yy.before(xx) mustBe true
+
+            assertOne(Rel.After)(xx, yy)
+          }
+        }
+      }
+    }
+
+    "a.before(b) AND b.after(a)" should {
+
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.before(yy)
+          val expected = yy.after(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in special cases" in {
         // Empty
         Interval.empty[Int].before(Interval.empty[Int]) mustBe (false)
         Interval.empty[Int].before(Interval.point(1)) mustBe (false)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/DuringSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/DuringSpec.scala
@@ -1,6 +1,7 @@
 package com.github.gchudnov.mtg.internal
 
 import com.github.gchudnov.mtg.Arbitraries.*
+import com.github.gchudnov.mtg.Boundary
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
@@ -20,6 +21,8 @@ final class DuringSpec extends TestSpec:
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
+
   "During" when {
     import IntervalRelAssert.*
 
@@ -33,6 +36,15 @@ final class DuringSpec extends TestSpec:
             yy.contains(xx) mustBe true
 
             assertOne(Rel.During)(xx, yy)
+
+            // a- > b- && a+ < b+
+            val a1 = Boundary.Left(ox1, ix1)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            val a2 = Boundary.Right(ox2, ix2)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            (ordB.gt(a1, b1) && ordB.lt(a2, b2)) mustBe true
           }
         }
       }
@@ -48,6 +60,15 @@ final class DuringSpec extends TestSpec:
             yy.during(xx) mustBe true
 
             assertOne(Rel.Contains)(xx, yy)
+
+            // a- < b- && b+ < a+
+            val a1 = Boundary.Left(ox1, ix1)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            val a2 = Boundary.Right(ox2, ix2)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            (ordB.lt(a1, b1) && ordB.lt(b2, a2)) mustBe true
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/DuringSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/DuringSpec.scala
@@ -21,21 +21,53 @@ final class DuringSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "During" when {
-    "during & contains (includes)" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.during(b)" should {
+      "b.contains(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.during(yy)) {
+            yy.contains(xx) mustBe true
+
             assertOne(Rel.During)(xx, yy)
           }
         }
       }
+    }
 
-      "manual check" in {
+    "a.contains(b)" should {
+      "b.during(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(xx.contains(yy)) {
+            yy.during(xx) mustBe true
+
+            assertOne(Rel.Contains)(xx, yy)
+          }
+        }
+      }
+    }
+
+    "a.during(b) AND b.contains(a)" should {
+
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.during(yy)
+          val expected = yy.contains(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in specal cases" in {
         // Empty
         Interval.empty[Int].during(Interval.open(5, 10)) mustBe (false)
         Interval.empty[Int].during(Interval.point(0)) mustBe (false)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/EqualsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/EqualsSpec.scala
@@ -46,6 +46,7 @@ final class EqualsSpec extends TestSpec:
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.equalsTo(yy)) {
+            // a- = b- && a+ = b+
             val a1 = Boundary.Left(ox1, ix1)
             val b1 = Boundary.Left(oy1, iy1)
 

--- a/src/test/scala/com/github/gchudnov/mtg/internal/EqualsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/EqualsSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 /**
  * Equals
@@ -13,29 +14,56 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
  *   BBBB
  * }}}
  */
-final class EqualsSpec extends TestSpec: // with IntervalRelAssert {}
+final class EqualsSpec extends TestSpec:
 
   given intRange: IntRange = intRange5
   given intProb: IntProb   = intProb127
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
-  "Equals" when {
-    "equals" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
 
+  "Equals" when {
+    import IntervalRelAssert.*
+
+    "a.equals(b)" should {
+
+      "b.equals(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.equalsTo(yy)
+          val expected = yy.equalsTo(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "a- = b- AND a+ = b+" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.equalsTo(yy)) {
+            val a1 = Boundary.Left(ox1, ix1)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            val a2 = Boundary.Right(ox2, ix2)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            val bothEmpty    = xx.isEmpty && yy.isEmpty
+            val eqBoundaries = (ordB.equiv(a1, b1) && ordB.equiv(a2, b2))
+
+            yy.equalsTo(xx) mustBe true
+            (bothEmpty || eqBoundaries) mustBe true
+
             assertOne(Rel.EqualsTo)(xx, yy)
           }
         }
       }
 
-      "manual check" in {
+      "valid in special cases" in {
         // Empty
         Interval.empty[Int].equalsTo(Interval.empty[Int]) mustBe (false)
         Interval.empty[Int].equalsTo(Interval.point(0)) mustBe (false)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/FinishesSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/FinishesSpec.scala
@@ -13,7 +13,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
  *   BBBBBB
  * }}}
  */
-final class FinishesSpec extends TestSpec: // with IntervalRelAssert {}
+final class FinishesSpec extends TestSpec:
 
   given intRange: IntRange = intRange5
   given intProb: IntProb   = intProb127
@@ -21,21 +21,53 @@ final class FinishesSpec extends TestSpec: // with IntervalRelAssert {}
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Finishes" when {
-    "finishes & isFinishedBy" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.finishes(b)" should {
+      "b.finisedBy(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.finishes(yy)) {
+            yy.isFinishedBy(xx) mustBe true
+
             assertOne(Rel.Finishes)(xx, yy)
           }
         }
       }
+    }
 
-      "manual check" in {
+    "a.finisedBy(b)" should {
+      "b.finishes(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(xx.isFinishedBy(yy)) {
+            yy.finishes(xx) mustBe true
+
+            assertOne(Rel.IsFinishedBy)(xx, yy)
+          }
+        }
+      }
+    }
+
+    "a.finishes(b) AND b.isFinishedBy(a)" should {
+
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.finishes(yy)
+          val expected = yy.isFinishedBy(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in special cases" in {
         // Empty
         Interval.empty[Int].finishes(Interval.empty[Int]) mustBe (false)
         Interval.empty[Int].finishes(Interval.point(0)) mustBe (false)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/GapSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/GapSpec.scala
@@ -14,6 +14,39 @@ final class GapSpec extends TestSpec:
 
   "Gap" when {
     "a.gap(b)" should {
+      "b.gap(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val zz = xx.gap(yy)
+
+          whenever(zz.nonEmpty) {
+            val ww = yy.gap(xx)
+
+            zz.canonical mustBe ww.canonical
+          }
+        }
+      }
+    }
+
+    "a.gap(b) AND b.gap(a)" should {
+
+      /**
+       * A ∥ B = B ∥ A
+       */
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.gap(yy).canonical
+          val expected = yy.gap(xx).canonical
+
+          actual mustBe expected
+        }
+      }
+
       "∅ if A and B are empty" in {
         val a = Interval.empty[Int]
         val b = Interval.empty[Int]
@@ -189,21 +222,6 @@ final class GapSpec extends TestSpec:
         c2 mustBe c1
 
         c1 mustBe expected
-      }
-    }
-
-    "A, B" should {
-
-      /**
-       * Commutative Property
-       */
-      "A || B = B || A" in {
-        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
-          val xx = Interval.make(ox1, ix1, ox2, ix2)
-          val yy = Interval.make(oy1, iy1, oy2, iy2)
-
-          xx.gap(yy).canonical mustBe yy.gap(xx).canonical
-        }
       }
     }
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/GapSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/GapSpec.scala
@@ -25,6 +25,14 @@ final class GapSpec extends TestSpec:
             val ww = yy.gap(xx)
 
             zz.canonical mustBe ww.canonical
+
+            // gap should be not intersecting with `a` or `b`
+            zz.intersects(xx) mustBe false
+            zz.intersects(yy) mustBe false
+
+            // gap must be adjacent
+            zz.isAdjacent(xx) mustBe true
+            zz.isAdjacent(yy) mustBe true
           }
         }
       }
@@ -45,6 +53,36 @@ final class GapSpec extends TestSpec:
 
           actual mustBe expected
         }
+      }
+
+      "∅ if A = [-inf, 0], B = (-inf, 0)" in {
+        // [-inf, inf)  [-inf, inf)
+        val xx = Interval.make[Int](None, true, Some(0), true)
+        val yy = Interval.make[Int](None, false, Some(0), false)
+
+        val zz = xx.gap(yy)
+
+        zz mustBe Interval.empty[Int]
+      }
+
+      "∅ if A = [-inf, inf), B = [-inf, inf)" in {
+        // [-inf, inf)  [-inf, inf)
+        val xx = Interval.make[Int](None, true, None, false)
+        val yy = Interval.make[Int](None, true, None, false)
+
+        val zz = xx.gap(yy)
+
+        zz mustBe Interval.empty[Int]
+      }
+
+      "∅ if A = [-inf, inf], B = [-inf, inf]" in {
+        // [-inf, inf)  [-inf, inf)
+        val xx = Interval.make[Int](None, true, None, true)
+        val yy = Interval.make[Int](None, true, None, true)
+
+        val zz = xx.gap(yy)
+
+        zz mustBe Interval.empty[Int]
       }
 
       "∅ if A and B are empty" in {

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IntersectionSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IntersectionSpec.scala
@@ -13,7 +13,52 @@ final class IntersectionSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Intersection" when {
+
     "a.intersection(b)" should {
+      "b.intersection(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val zz = xx.intersection(yy)
+
+          whenever(zz.nonEmpty) {
+            val ww = yy.intersection(xx)
+
+            zz.canonical mustBe ww.canonical
+          }
+        }
+      }
+    }
+
+    "a.intersection(b) AND b.intersection(a)" should {
+
+      /**
+       * A & B = B & A
+       */
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.intersection(yy).canonical
+          val expected = yy.intersection(xx).canonical
+
+          actual mustBe expected
+        }
+      }
+
+      "(2, +∞] & (3, 5) = (3, 5) & (2, +∞]" in {
+        val a = Interval.leftOpen(2)                          // (2, +∞]
+        val b = Interval.make(Some(3), false, Some(5), false) // (3, 5)
+
+        val c1 = a.intersection(b).canonical
+        val c2 = b.intersection(a).canonical
+
+        c1 mustBe c2
+        c2 mustBe c1
+      }
+
       "∅ if A and B are empty" in {
         val a = Interval.empty[Int]
         val b = Interval.empty[Int]
@@ -195,32 +240,6 @@ final class IntersectionSpec extends TestSpec:
       }
     }
 
-    "A, B" should {
-
-      /**
-       * Commutative Property
-       */
-      "A & B = B & A" in {
-        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
-          val xx = Interval.make(ox1, ix1, ox2, ix2)
-          val yy = Interval.make(oy1, iy1, oy2, iy2)
-
-          xx.intersection(yy).canonical mustBe yy.intersection(xx).canonical
-        }
-      }
-
-      "(2, +∞] & (3, 5) = (3, 5) & (2, +∞]" in {
-        val a = Interval.leftOpen(2)                          // (2, +∞]
-        val b = Interval.make(Some(3), false, Some(5), false) // (3, 5)
-
-        val c1 = a.intersection(b).canonical
-        val c2 = b.intersection(a).canonical
-
-        c1 mustBe c2
-        c2 mustBe c1
-      }
-    }
-
     "Interval" should {
       "Interval.intersection(a, b)" in {
         val a = Interval.rightClosed(2) // (-∞, 2]
@@ -239,17 +258,16 @@ final class IntersectionSpec extends TestSpec:
     }
 
     "A, B, C" should {
-
-      /**
-       * Associative Property
-       */
       "(A & B) & C = A & (B & C)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2)), ((oz1, iz1), (oz2, iz2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
           val zz = Interval.make(oz1, iz1, oz2, iz2)
 
-          ((xx.intersection(yy)).intersection(zz)).canonical mustBe xx.intersection(yy.intersection(zz)).canonical
+          val actual   = ((xx.intersection(yy)).intersection(zz)).canonical
+          val expected = xx.intersection(yy.intersection(zz)).canonical
+
+          actual mustBe expected
         }
       }
     }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IntersectionSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IntersectionSpec.scala
@@ -26,6 +26,15 @@ final class IntersectionSpec extends TestSpec:
             val ww = yy.intersection(xx)
 
             zz.canonical mustBe ww.canonical
+
+            // TODO: (-inf, +inf) if A = (-inf, +inf], B = [-inf, +inf)
+            // TODO: things break with inf values, fix it
+            // // given the gap c, [-inf, c-) || (c+, +inf] must be the intersection
+            // val cLhs = Interval.make[Int](None, true, zz.left.effectiveValue, true)
+            // val cRhs = Interval.make[Int](zz.right.effectiveValue, true, None, true)
+
+            // val cc = cLhs.gap(cRhs)
+            // cc.canonical mustBe zz.canonical
           }
         }
       }
@@ -46,6 +55,16 @@ final class IntersectionSpec extends TestSpec:
 
           actual mustBe expected
         }
+      }
+
+      "(-inf, +inf) if A = (-inf, +inf], B = [-inf, +inf)" in {
+        val xx = Interval.make[Int](None, false, None, true)
+        val yy = Interval.make[Int](None, true, None, false)
+
+        val actual   = xx.intersection(yy)
+        val expected = Interval.make[Int](None, false, None, false)
+
+        actual mustBe expected
       }
 
       "(2, +∞] & (3, 5) = (3, 5) & (2, +∞]" in {

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IntersectsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IntersectsSpec.scala
@@ -16,23 +16,40 @@ final class IntersectsSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Intersects" when {
-    "intersects" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.intersects(b)" should {
+      "b.intersects(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.intersects(yy)) {
+            yy.intersects(xx) mustBe true
+
             assertOneOf(
               Set(Rel.Meets, Rel.IsMetBy, Rel.Overlaps, Rel.IsOverlapedBy, Rel.During, Rel.Contains, Rel.Starts, Rel.IsStartedBy, Rel.Finishes, Rel.IsFinishedBy, Rel.EqualsTo)
             )(xx, yy)
           }
         }
       }
+    }
 
-      "manual check" in {
+    "a.intersects(b) AND b.intersects(a)" should {
+
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.intersects(yy)
+          val expected = yy.intersects(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in special cases" in {
         // Empty
         Interval.empty[Int].intersects(Interval.empty[Int]) mustBe (false)
         Interval.empty[Int].intersects(Interval.point(0)) mustBe (false)
@@ -54,21 +71,6 @@ final class IntersectsSpec extends TestSpec:
         // Infinity
         // [5, +inf)  (-inf, 10)
         Interval.leftClosed(5).intersects(Interval.rightOpen(10)) mustBe (true)
-      }
-    }
-
-    "A, B" should {
-
-      /**
-       * Commutative Property
-       */
-      "A interscts B = B interscts A" in {
-        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
-          val xx = Interval.make(ox1, ix1, ox2, ix2)
-          val yy = Interval.make(oy1, iy1, oy2, iy2)
-
-          xx.intersects(yy) mustBe yy.intersects(xx)
-        }
       }
     }
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IntersectsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IntersectsSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 /**
  * Intersects
@@ -14,6 +15,8 @@ final class IntersectsSpec extends TestSpec:
   given intProb: IntProb   = intProb127
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
+
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
 
   "Intersects" when {
     import IntervalRelAssert.*
@@ -30,6 +33,15 @@ final class IntersectsSpec extends TestSpec:
             assertOneOf(
               Set(Rel.Meets, Rel.IsMetBy, Rel.Overlaps, Rel.IsOverlapedBy, Rel.During, Rel.Contains, Rel.Starts, Rel.IsStartedBy, Rel.Finishes, Rel.IsFinishedBy, Rel.EqualsTo)
             )(xx, yy)
+
+            // a- <= b+ && b- <= a+
+            val a1 = Boundary.Left(ox1, ix1)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            val a2 = Boundary.Right(ox2, ix2)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            (ordB.lteq(a1, b2) && ordB.lteq(b1, a2)) mustBe (true)
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsAdjacentSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsAdjacentSpec.scala
@@ -13,47 +13,49 @@ final class IsAdjacentSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "IsAdjacent" when {
-    "isAdjacent" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.isAdjacent(b)" should {
+      "b.isAdjacent(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.isAdjacent(yy)) {
+            yy.isAdjacent(xx) mustBe true
+
             assertOneOf(Set(Rel.Before, Rel.After))(xx, yy)
           }
         }
       }
     }
 
-    "manual check" in {
-      // (1, 4)  (3, 6)
-      Interval.open(1, 4).isAdjacent(Interval.open(3, 6)) mustBe (true)
-      Interval.open(3, 6).isAdjacent(Interval.open(1, 4)) mustBe (true)
+    "a.isAdjacent(b) AND b.isAdjacent(a)" should {
 
-      // (1, 4)  (4, 6)
-      Interval.open(1, 4).isAdjacent(Interval.open(4, 7)) mustBe (false)
-      Interval.open(4, 7).isAdjacent(Interval.open(1, 4)) mustBe (false)
-
-      // [1, 4]  [5, 6]
-      Interval.closed(1, 4).isAdjacent(Interval.closed(5, 6)) mustBe (true)
-      Interval.closed(5, 6).isAdjacent(Interval.closed(1, 4)) mustBe (true)
-    }
-
-    "A, B" should {
-
-      /**
-       * Commutative Property
-       */
-      "A is-adjacent B = B is-adjacent A" in {
+      "equal" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
-          xx.isAdjacent(yy) mustBe yy.isAdjacent(xx)
+          val actual   = xx.isAdjacent(yy)
+          val expected = yy.isAdjacent(xx)
+
+          actual mustBe expected
         }
+      }
+
+      "valid in special cases" in {
+        // (1, 4)  (3, 6)
+        Interval.open(1, 4).isAdjacent(Interval.open(3, 6)) mustBe (true)
+        Interval.open(3, 6).isAdjacent(Interval.open(1, 4)) mustBe (true)
+
+        // (1, 4)  (4, 6)
+        Interval.open(1, 4).isAdjacent(Interval.open(4, 7)) mustBe (false)
+        Interval.open(4, 7).isAdjacent(Interval.open(1, 4)) mustBe (false)
+
+        // [1, 4]  [5, 6]
+        Interval.closed(1, 4).isAdjacent(Interval.closed(5, 6)) mustBe (true)
+        Interval.closed(5, 6).isAdjacent(Interval.closed(1, 4)) mustBe (true)
       }
     }
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsAdjacentSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsAdjacentSpec.scala
@@ -29,6 +29,7 @@ final class IsAdjacentSpec extends TestSpec:
 
             assertOneOf(Set(Rel.Before, Rel.After))(xx, yy)
 
+            // succ(a+) = b- OR succ(b+) = a-
             if xx.before(yy) then
               // succ(a+) = b-
               val b1 = Boundary.Left(oy1, iy1)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsAdjacentSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsAdjacentSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 final class IsAdjacentSpec extends TestSpec:
 
@@ -11,6 +12,8 @@ final class IsAdjacentSpec extends TestSpec:
   given intProb: IntProb   = intProb127
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
+
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
 
   "IsAdjacent" when {
     import IntervalRelAssert.*
@@ -25,6 +28,19 @@ final class IsAdjacentSpec extends TestSpec:
             yy.isAdjacent(xx) mustBe true
 
             assertOneOf(Set(Rel.Before, Rel.After))(xx, yy)
+
+            if xx.before(yy) then
+              // succ(a+) = b-
+              val b1 = Boundary.Left(oy1, iy1)
+              val a2 = Boundary.Right(ox2, ix2)
+
+              ordB.equiv(a2.succ, b1) mustBe (true)
+            else if xx.after(yy) then
+              // succ(b+) = a-
+              val a1 = Boundary.Left(ox1, ix1)
+              val b2 = Boundary.Right(oy2, iy2)
+
+              ordB.equiv(b2.succ, a1) mustBe (true)
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsDisjointSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsDisjointSpec.scala
@@ -13,23 +13,39 @@ final class IsDisjointSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "IsDisjoint" when {
-    "isDisjoint" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.isDisjoint(b)" should {
+      "b.isDisjoint(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.isDisjoint(yy)) {
+            yy.isDisjoint(xx) mustBe true
+
             assertOneOf(Set(Rel.Before, Rel.After))(xx, yy)
           }
         }
       }
     }
 
-    "manual check" in {
-      Interval.open(1, 4).isDisjoint(Interval.open(3, 6)) mustBe (true)
-      Interval.open(3, 6).isDisjoint(Interval.open(1, 4)) mustBe (true)
+    "a.isDisjoint(b) AND b.isDisjoint(a)" should {
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.isDisjoint(yy)
+          val expected = yy.isDisjoint(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in special cases" in {
+        Interval.open(1, 4).isDisjoint(Interval.open(3, 6)) mustBe (true)
+        Interval.open(3, 6).isDisjoint(Interval.open(1, 4)) mustBe (true)
+      }
     }
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsDisjointSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsDisjointSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 final class IsDisjointSpec extends TestSpec:
 
@@ -11,6 +12,8 @@ final class IsDisjointSpec extends TestSpec:
   given intProb: IntProb   = intProb127
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
+
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
 
   "IsDisjoint" when {
     import IntervalRelAssert.*
@@ -25,6 +28,15 @@ final class IsDisjointSpec extends TestSpec:
             yy.isDisjoint(xx) mustBe true
 
             assertOneOf(Set(Rel.Before, Rel.After))(xx, yy)
+
+            // a+ < b- || a- > b+
+            val a1 = Boundary.Left(ox1, ix1)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            val a2 = Boundary.Right(ox2, ix2)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            (ordB.lt(xx.right, yy.left) || ordB.gt(xx.left, yy.right)) mustBe true
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsLessSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsLessSpec.scala
@@ -24,24 +24,68 @@ final class IsLessSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "IsLess" when {
-    "isLess" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.isLess(b)" should {
+      "b.isGreater(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.isLess(yy)) {
+            yy.isGreater(xx) mustBe true
+
             assertOneOf(Set(Rel.Before, Rel.Meets, Rel.Overlaps))(xx, yy)
           }
         }
       }
+    }
 
-      "manual check" in {
+    "a.isGreater(b)" should {
+      "b.isLess(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(xx.isGreater(yy)) {
+            yy.isLess(xx) mustBe true
+
+            assertOneOf(Set(Rel.After, Rel.IsMetBy, Rel.IsOverlapedBy))(xx, yy)
+          }
+        }
+      }
+    }
+
+    "a.isLess(b) AND b.isGreater(a)" should {
+
+      "verify" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(!xx.equalsTo(yy)) {
+            val actual   = xx.isLess(yy)
+            val expected = yy.isGreater(xx)
+
+            actual mustBe expected
+          }
+        }
+      }
+
+      "valid in special cases" in {
         Interval.open(4, 7).isLess(Interval.open(10, 15)) mustBe (true)
         Interval.open(4, 7).isLess(Interval.open(6, 15)) mustBe (true)
         Interval.open(4, 7).isLess(Interval.open(5, 15)) mustBe (true)
+
+        Interval.empty[Int].isLess(Interval.empty[Int]) mustBe (false)
+        Interval.empty[Int].isGreater(Interval.empty[Int]) mustBe (false)
+        Interval.empty[Int].equalsTo(Interval.empty[Int]) mustBe (false)
+
+        Interval.open(1, 5).isLess(Interval.empty[Int]) mustBe(false)
+        Interval.empty[Int].isLess(Interval.open(1, 5)) mustBe(false)
+
+        Interval.open(1, 5).isGreater(Interval.empty[Int]) mustBe(false)
+        Interval.empty[Int].isGreater(Interval.open(1, 5)) mustBe(false)
       }
     }
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsLessSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsLessSpec.scala
@@ -81,11 +81,11 @@ final class IsLessSpec extends TestSpec:
         Interval.empty[Int].isGreater(Interval.empty[Int]) mustBe (false)
         Interval.empty[Int].equalsTo(Interval.empty[Int]) mustBe (false)
 
-        Interval.open(1, 5).isLess(Interval.empty[Int]) mustBe(false)
-        Interval.empty[Int].isLess(Interval.open(1, 5)) mustBe(false)
+        Interval.open(1, 5).isLess(Interval.empty[Int]) mustBe (false)
+        Interval.empty[Int].isLess(Interval.open(1, 5)) mustBe (false)
 
-        Interval.open(1, 5).isGreater(Interval.empty[Int]) mustBe(false)
-        Interval.empty[Int].isGreater(Interval.open(1, 5)) mustBe(false)
+        Interval.open(1, 5).isGreater(Interval.empty[Int]) mustBe (false)
+        Interval.empty[Int].isGreater(Interval.open(1, 5)) mustBe (false)
       }
     }
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsSubsetSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsSubsetSpec.scala
@@ -25,21 +25,23 @@ final class IsSubsetSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "IsSubset" when {
-    "isSubset" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.isSubset(b)" should {
+      "b.isSuperset(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.isSubset(yy)) {
+            yy.isSuperset(xx) mustBe true
+
             assertOneOf(Set(Rel.Starts, Rel.During, Rel.Finishes, Rel.EqualsTo))(xx, yy)
           }
         }
       }
 
-      "manual check" in {
+      "valid in special cases" in {
         Interval.open(4, 7).isSubset(Interval.open(4, 10)) mustBe (true)
         Interval.open(4, 7).isSubset(Interval.open(2, 10)) mustBe (true)
         Interval.open(4, 7).isSubset(Interval.open(2, 7)) mustBe (true)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsSubsetSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsSubsetSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 /**
  * IsSubset
@@ -24,6 +25,8 @@ final class IsSubsetSpec extends TestSpec:
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
+
   "IsSubset" when {
     import IntervalRelAssert.*
 
@@ -37,6 +40,9 @@ final class IsSubsetSpec extends TestSpec:
             yy.isSuperset(xx) mustBe true
 
             assertOneOf(Set(Rel.Starts, Rel.During, Rel.Finishes, Rel.EqualsTo))(xx, yy)
+
+            // b- <= a- && b+ >= a+
+            (ordB.lteq(yy.left, xx.left) && ordB.gteq(yy.right, xx.right)) mustBe true
           }
         }
       }
@@ -46,6 +52,8 @@ final class IsSubsetSpec extends TestSpec:
         Interval.open(4, 7).isSubset(Interval.open(2, 10)) mustBe (true)
         Interval.open(4, 7).isSubset(Interval.open(2, 7)) mustBe (true)
         Interval.open(4, 7).isSubset(Interval.open(4, 7)) mustBe (true)
+
+        Interval.closed(1, 10).isSubset(Interval.unbounded[Int]) mustBe(true)
       }
     }
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsSupersetSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsSupersetSpec.scala
@@ -13,21 +13,24 @@ final class IsSupersetSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "IsSuperset" when {
-    "isSuperset" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
+
+    "a.isSuperset(b)" should {
+      "b.isSubset(a)" in {
 
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.isSuperset(yy)) {
+            yy.isSubset(xx) mustBe true
+
             assertOneOf(Set(Rel.IsStartedBy, Rel.Contains, Rel.IsFinishedBy, Rel.EqualsTo))(xx, yy)
           }
         }
       }
 
-      "manual check" in {
+      "valid in special cases" in {
         Interval.open(4, 10).isSuperset(Interval.open(4, 7)) mustBe (true)
         Interval.open(2, 10).isSuperset(Interval.open(4, 7)) mustBe (true)
         Interval.open(2, 7).isSuperset(Interval.open(4, 7)) mustBe (true)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/IsSupersetSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/IsSupersetSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 final class IsSupersetSpec extends TestSpec:
 
@@ -11,6 +12,8 @@ final class IsSupersetSpec extends TestSpec:
   given intProb: IntProb   = intProb127
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
+
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
 
   "IsSuperset" when {
     import IntervalRelAssert.*
@@ -26,6 +29,9 @@ final class IsSupersetSpec extends TestSpec:
             yy.isSubset(xx) mustBe true
 
             assertOneOf(Set(Rel.IsStartedBy, Rel.Contains, Rel.IsFinishedBy, Rel.EqualsTo))(xx, yy)
+
+            // a- <= b- && a+ >= b+
+            (ordB.lteq(xx.left, yy.left) && ordB.gteq(xx.right, yy.right)) mustBe true
           }
         }
       }
@@ -35,6 +41,8 @@ final class IsSupersetSpec extends TestSpec:
         Interval.open(2, 10).isSuperset(Interval.open(4, 7)) mustBe (true)
         Interval.open(2, 7).isSuperset(Interval.open(4, 7)) mustBe (true)
         Interval.open(4, 7).isSuperset(Interval.open(4, 7)) mustBe (true)
+
+        Interval.unbounded[Int].isSuperset(Interval.closed(1, 10)) mustBe (true)
       }
     }
   }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/MeetsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/MeetsSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 /**
  * Meets, IsMetBy
@@ -20,6 +21,8 @@ final class MeetsSpec extends TestSpec: // with IntervalRelAssert {}
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
+
   "Meets" when {
     import IntervalRelAssert.*
 
@@ -33,6 +36,12 @@ final class MeetsSpec extends TestSpec: // with IntervalRelAssert {}
             yy.isMetBy(xx) mustBe true
 
             assertOne(Rel.Meets)(xx, yy)
+
+            // a+ = b-
+            val a2 = Boundary.Right(ox2, ix2)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            ordB.equiv(a2, b1) mustBe true
           }
         }
       }
@@ -48,6 +57,12 @@ final class MeetsSpec extends TestSpec: // with IntervalRelAssert {}
             yy.meets(xx) mustBe true
 
             assertOne(Rel.IsMetBy)(xx, yy)
+
+            // b+ = a-
+            val a1 = Boundary.Left(ox1, ix1)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            ordB.equiv(b2, a1) mustBe true
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/MeetsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/MeetsSpec.scala
@@ -21,21 +21,52 @@ final class MeetsSpec extends TestSpec: // with IntervalRelAssert {}
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Meets" when {
-    "meets & isMetBy" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.meets(b)" should {
+      "b.isMetBy(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.meets(yy)) {
+            yy.isMetBy(xx) mustBe true
+
             assertOne(Rel.Meets)(xx, yy)
           }
         }
       }
+    }
 
-      "manual check" in {
+    "a.isMetBy(b)" should {
+      "b.meets(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(xx.isMetBy(yy)) {
+            yy.meets(xx) mustBe true
+
+            assertOne(Rel.IsMetBy)(xx, yy)
+          }
+        }
+      }
+    }
+
+    "a.meets(b) AND b.isMetBy(a)" should {
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.meets(yy)
+          val expected = yy.isMetBy(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in special cases" in {
         // Empty
         Interval.empty[Int].meets(Interval.empty[Int]) mustBe (false)
         Interval.empty[Int].meets(Interval.point(0)) mustBe (false)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/MergesSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/MergesSpec.scala
@@ -16,8 +16,53 @@ final class MergesSpec extends TestSpec:
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Merges" when {
-    "merges & isMergedBy" should {
-      "manual check" in {
+    import IntervalRelAssert.*
+
+    "a.merges(b)" should {
+      "b.merges(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(xx.merges(yy)) {
+            yy.merges(xx) mustBe true
+
+            assertOneOf(
+              Set(
+                Rel.Meets,
+                Rel.IsMetBy,
+                Rel.Overlaps,
+                Rel.IsOverlapedBy,
+                Rel.During,
+                Rel.Contains,
+                Rel.Starts,
+                Rel.IsStartedBy,
+                Rel.Finishes,
+                Rel.IsFinishedBy,
+                Rel.EqualsTo,
+                Rel.Before,
+                Rel.After
+              )
+            )(xx, yy)
+          }
+        }
+      }
+    }
+
+    "a.merges(b) AND b.merges(a)" should {
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.merges(yy)
+          val expected = yy.merges(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in special cases" in {
         // Empty
         Interval.empty[Int].merges(Interval.empty[Int]) mustBe (false)
         Interval.empty[Int].merges(Interval.point(1)) mustBe (false)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/MinusSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/MinusSpec.scala
@@ -1,10 +1,11 @@
 package com.github.gchudnov.mtg.internal
 
 import com.github.gchudnov.mtg.Arbitraries.*
+import com.github.gchudnov.mtg.Boundary
 import com.github.gchudnov.mtg.Interval
+import com.github.gchudnov.mtg.Intervals
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
-import com.github.gchudnov.mtg.Intervals
 
 final class MinusSpec extends TestSpec:
 
@@ -13,8 +14,36 @@ final class MinusSpec extends TestSpec:
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
+
   "Minus" when {
     "a.minus(b)" should {
+
+      // TODO: re-enable and fix when we fix infinity
+      // "verify" in {
+      //   forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+      //     val xx = Interval.make(ox1, ix1, ox2, ix2)
+      //     val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+      //     whenever(xx.nonEmpty && yy.nonEmpty && !xx.contains(yy)) {
+      //       val zz = xx.minus(yy)
+
+      //       if zz.nonEmpty then
+      //         // NOTE: a.minus(b) is defined only if and only if:
+      //         //   - (a) `a` and `b` are disjoint;
+      //         //   - (b) `a` contains either `b-` or `b+` but not both;
+      //         //   - (c) either b.starts(a) or b.finishes(a) is true;
+      //         // xx.intersects(yy) && !xx.isSuperset(yy) mustBe true
+      //       else
+      //         // NOTE: a.minus(b) is undefined if:
+      //         //   - either a.starts(b) or a.finishes(b);
+      //         //   - either `a` or `b` is properly included in the other;
+      //         // xx.isSubset(yy) mustBe true
+      //     }
+
+      //   }
+      // }
+
       "∅ if A and B are empty" in {
         val a = Interval.empty[Int]
         val b = Interval.empty[Int]

--- a/src/test/scala/com/github/gchudnov/mtg/internal/OverlapsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/OverlapsSpec.scala
@@ -21,21 +21,52 @@ final class OverlapsSpec extends TestSpec: // with IntervalRelAssert {}
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Overlap" when {
-    "overlaps & isOverlapedBy" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.overlaps(b)" should {
+      "b.isOverlapedBy(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.overlaps(yy)) {
+            yy.isOverlapedBy(xx) mustBe true
+
             assertOne(Rel.Overlaps)(xx, yy)
           }
         }
       }
+    }
 
-      "manual check" in {
+    "a.isOverlapedBy(b)" should {
+      "b.overlaps(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(xx.isOverlapedBy(yy)) {
+            yy.overlaps(xx) mustBe true
+
+            assertOne(Rel.IsOverlapedBy)(xx, yy)
+          }
+        }
+      }
+    }
+
+    "a.overlaps(b) AND b.isOverlapedBy(a)" should {
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.overlaps(yy)
+          val expected = yy.isOverlapedBy(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in special cases" in {
         // Empty
         // {}  (-inf, +inf)
         Interval.empty[Int].overlaps(Interval.unbounded[Int]) mustBe (false)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/OverlapsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/OverlapsSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 /**
  * Overlaps, IsOverlapedBy
@@ -20,6 +21,8 @@ final class OverlapsSpec extends TestSpec: // with IntervalRelAssert {}
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
+
   "Overlap" when {
     import IntervalRelAssert.*
 
@@ -33,6 +36,15 @@ final class OverlapsSpec extends TestSpec: // with IntervalRelAssert {}
             yy.isOverlapedBy(xx) mustBe true
 
             assertOne(Rel.Overlaps)(xx, yy)
+
+            // a- < b+ && b- < a+
+            val a1 = Boundary.Left(ox1, ix1)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            val a2 = Boundary.Right(ox2, ix2)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            (ordB.lt(a1, b2) && ordB.lt(b1, a2)) mustBe true
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/RelBasicSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/RelBasicSpec.scala
@@ -25,7 +25,7 @@ final class BasicRelSpec extends TestSpec:
         }
       }
 
-      "manual check" in {
+      "valid in special cases" in {
         val intervals = List(
           (Interval.rightOpen(5), Interval.rightOpen(5)) // (-inf, 5)  (5, +inf)
         )

--- a/src/test/scala/com/github/gchudnov/mtg/internal/SpanSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/SpanSpec.scala
@@ -14,6 +14,40 @@ final class SpanSpec extends TestSpec:
 
   "Span" when {
     "a.span(b)" should {
+
+      "b.span(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val zz = xx.span(yy)
+
+          whenever(zz.nonEmpty) {
+            val ww = yy.span(xx)
+
+            zz.canonical mustBe ww.canonical
+          }
+        }
+      }
+    }
+
+    "a.span(b) AND b.span(a)" should {
+
+      /**
+       * A # B = B # A
+       */
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.span(yy).canonical
+          val expected = yy.span(xx).canonical
+
+          actual mustBe expected
+        }
+      }
+
       "∅ if A and B are empty" in {
         val a = Interval.empty[Int]
         val b = Interval.empty[Int]
@@ -192,33 +226,17 @@ final class SpanSpec extends TestSpec:
       }
     }
 
-    "A, B" should {
-
-      /**
-       * Commutative Property
-       */
-      "A # B = B # A" in {
-        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
-          val xx = Interval.make(ox1, ix1, ox2, ix2)
-          val yy = Interval.make(oy1, iy1, oy2, iy2)
-
-          xx.span(yy).canonical mustBe yy.span(xx).canonical
-        }
-      }
-    }
-
     "A, B, C" should {
-
-      /**
-       * Associative Property
-       */
       "(A # B) # C = A # (B # C)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2)), ((oz1, iz1), (oz2, iz2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
           val zz = Interval.make(oz1, iz1, oz2, iz2)
 
-          ((xx.span(yy)).span(zz)).canonical mustBe xx.span(yy.span(zz)).canonical
+          val actual   = ((xx.span(yy)).span(zz)).canonical
+          val expected = xx.span(yy.span(zz)).canonical
+
+          actual mustBe expected
         }
       }
     }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/SpanSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/SpanSpec.scala
@@ -26,6 +26,11 @@ final class SpanSpec extends TestSpec:
             val ww = yy.span(xx)
 
             zz.canonical mustBe ww.canonical
+
+            // [min(a-, b-), max(a+, b+)]
+            // given span `c`, `c` intersection with `a` = `a` AND `c` intersects with `b` = `b`
+            zz.intersection(xx).canonical mustBe xx.canonical
+            zz.intersection(yy).canonical mustBe yy.canonical
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/StartsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/StartsSpec.scala
@@ -37,16 +37,11 @@ final class StartsSpec extends TestSpec: // with IntervalRelAssert {}
 
             assertOne(Rel.Starts)(xx, yy)
 
-            // a- = b- && b.isSuperset(a+)
+            // a- = b- && b.isSuperset(a) && !a.equalsTo(b)
             val a1 = Boundary.Left(ox1, ix1)
             val b1 = Boundary.Left(oy1, iy1)
 
-            val a2 = Boundary.Right(ox2, ix2)
-            val b2 = Boundary.Right(oy2, iy2)
-
-            ordB.equiv(a1, b1) mustBe true
-
-            yy.isSuperset(Interval.make(a2.asLeft, a2.asRight)) mustBe true
+            (ordB.equiv(a1, b1) && yy.isSuperset(xx) && !xx.equalsTo(yy)) mustBe true
           }
         }
       }
@@ -62,6 +57,12 @@ final class StartsSpec extends TestSpec: // with IntervalRelAssert {}
             yy.starts(xx) mustBe true
 
             assertOne(Rel.IsStartedBy)(xx, yy)
+
+            // a- = b- && a.isSuperset(b) && !a.equalsTo(b)
+            val a1 = Boundary.Left(ox1, ix1)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            (ordB.equiv(a1, b1) && xx.isSuperset(yy) && !xx.equalsTo(yy)) mustBe true
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/StartsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/StartsSpec.scala
@@ -4,6 +4,7 @@ import com.github.gchudnov.mtg.Arbitraries.*
 import com.github.gchudnov.mtg.Interval
 import com.github.gchudnov.mtg.TestSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.*
+import com.github.gchudnov.mtg.Boundary
 
 /**
  * Starts, IsStartedBy
@@ -20,6 +21,8 @@ final class StartsSpec extends TestSpec: // with IntervalRelAssert {}
 
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
+  val ordB: Ordering[Boundary[Int]] = summon[Ordering[Boundary[Int]]]
+
   "Starts" when {
     import IntervalRelAssert.*
 
@@ -33,6 +36,17 @@ final class StartsSpec extends TestSpec: // with IntervalRelAssert {}
             yy.isStartedBy(xx) mustBe true
 
             assertOne(Rel.Starts)(xx, yy)
+
+            // a- = b- && b.isSuperset(a+)
+            val a1 = Boundary.Left(ox1, ix1)
+            val b1 = Boundary.Left(oy1, iy1)
+
+            val a2 = Boundary.Right(ox2, ix2)
+            val b2 = Boundary.Right(oy2, iy2)
+
+            ordB.equiv(a1, b1) mustBe true
+
+            yy.isSuperset(Interval.make(a2.asLeft, a2.asRight)) mustBe true
           }
         }
       }

--- a/src/test/scala/com/github/gchudnov/mtg/internal/StartsSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/StartsSpec.scala
@@ -21,21 +21,52 @@ final class StartsSpec extends TestSpec: // with IntervalRelAssert {}
   given config: PropertyCheckConfiguration = PropertyCheckConfiguration(maxDiscardedFactor = 1000.0)
 
   "Starts" when {
-    "starts & isStartedBy" should {
-      "auto check" in {
-        import IntervalRelAssert.*
+    import IntervalRelAssert.*
 
+    "a.starts(b)" should {
+      "b.isStartedBy(a)" in {
         forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
           val xx = Interval.make(ox1, ix1, ox2, ix2)
           val yy = Interval.make(oy1, iy1, oy2, iy2)
 
           whenever(xx.starts(yy)) {
+            yy.isStartedBy(xx) mustBe true
+
             assertOne(Rel.Starts)(xx, yy)
           }
         }
       }
+    }
 
-      "manual check" in {
+    "a.isStartedBy(b)" should {
+      "b.starts(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          whenever(xx.isStartedBy(yy)) {
+            yy.starts(xx) mustBe true
+
+            assertOne(Rel.IsStartedBy)(xx, yy)
+          }
+        }
+      }
+    }
+
+    "a.starts(b) AND b.isStartedBy(a)" should {
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.starts(yy)
+          val expected = yy.isStartedBy(xx)
+
+          actual mustBe expected
+        }
+      }
+
+      "valid in special cases" in {
         // Empty
         Interval.empty[Int].starts(Interval.point(0)) mustBe (false)
         Interval.empty[Int].starts(Interval.closed(0, 1)) mustBe (false)

--- a/src/test/scala/com/github/gchudnov/mtg/internal/UnionSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/UnionSpec.scala
@@ -14,6 +14,35 @@ final class UnionSpec extends TestSpec:
 
   "Union" when {
     "a.union(b)" should {
+      "b.union(a)" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val zz = xx.union(yy)
+
+          whenever(zz.nonEmpty) {
+            val ww = yy.union(xx)
+
+            zz.canonical mustBe ww.canonical
+          }
+        }
+      }
+    }
+
+    "a.union(b) AND b.union(a)" should {
+      "equal" in {
+        forAll(genOneOfIntArgs, genOneOfIntArgs) { case (((ox1, ix1), (ox2, ix2)), ((oy1, iy1), (oy2, iy2))) =>
+          val xx = Interval.make(ox1, ix1, ox2, ix2)
+          val yy = Interval.make(oy1, iy1, oy2, iy2)
+
+          val actual   = xx.union(yy).canonical
+          val expected = yy.union(xx).canonical
+
+          actual mustBe expected
+        }
+      }
+
       "∅ if A and B are empty" in {
         val a = Interval.empty[Int]
         val b = Interval.empty[Int]

--- a/src/test/scala/com/github/gchudnov/mtg/internal/UnionSpec.scala
+++ b/src/test/scala/com/github/gchudnov/mtg/internal/UnionSpec.scala
@@ -25,6 +25,9 @@ final class UnionSpec extends TestSpec:
             val ww = yy.union(xx)
 
             zz.canonical mustBe ww.canonical
+
+            xx.merges(yy) mustBe (true)
+            yy.merges(xx) mustBe (true)
           }
         }
       }


### PR DESCRIPTION
Add laws tests:

- X ~1) ∼(A&B) = A∥B.~
- [x] 2) A&B = B&A
- [x] 3) A#B = B#A
- [x] 4) A∥B = B∥A
- [x] 5) (A&B)&C = A&(B&C)
- [x] 6) (A#B)#C = A#(B#C)
- X ~7) d(A) ≤ 0 if A is a null interval.~
- X 8) ~d(A&B) < 0 if A and B are separate.~
- X 9) ~d(A&B) = 0 if A abuts B.~
- X 10) ~d(A&B) > 0 if A intersects B.~

UPD: cancelled some tests, since it is not convenient to work with infinite values: -inf, +inf

closes #24 